### PR TITLE
Adding ipv6 support to AUKS, based on adapt_k5 branch

### DIFF
--- a/src/api/auks/auks_acl.c
+++ b/src/api/auks/auks_acl.c
@@ -435,7 +435,9 @@ _auks_acl_rule_check_host(auks_acl_rule_t * p_rule,char *host)
 	struct addrinfo *aitop;
 	struct addrinfo hints;
 	struct addrinfo *ai;
-	struct sockaddr_in addr;
+	struct sockaddr_in6 addr;
+
+	char str_ipv6_inet_addr[INET6_ADDRSTRLEN];
 
 	/* all nodes match */
 	if (strncmp(p_rule->host, "*", 2) == 0) {
@@ -459,7 +461,7 @@ _auks_acl_rule_check_host(auks_acl_rule_t * p_rule,char *host)
 		for (ai = aitop; ai; ai = ai->ai_next) {
 			char * rule_host;
 			memcpy(&addr, ai->ai_addr, ai->ai_addrlen);
-			rule_host = inet_ntoa((struct in_addr) addr.sin_addr);
+			rule_host = inet_ntop(AF_INET6, &addr.sin6_addr, str_ipv6_inet_addr, sizeof(str_ipv6_inet_addr));
 			if (strncmp(host, rule_host, strlen(host) + 1) ==
 			    0) {
 				fstatus = AUKS_SUCCESS;

--- a/src/api/auks/auks_acl.c
+++ b/src/api/auks/auks_acl.c
@@ -453,7 +453,7 @@ _auks_acl_rule_check_host(auks_acl_rule_t * p_rule,char *host)
 	/* check matching DNS entries */
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_flags = AI_CANONNAME;
-	hints.ai_family = AF_INET;
+	hints.ai_family = AF_INET6;
 	hints.ai_socktype = SOCK_STREAM;
 	if (getaddrinfo(p_rule->host, "", &hints, &aitop) == 0) {
 		for (ai = aitop; ai; ai = ai->ai_next) {

--- a/src/api/auks/auks_krb5_stream.c
+++ b/src/api/auks/auks_krb5_stream.c
@@ -375,11 +375,11 @@ auks_krb5_stream_authenticate(auks_krb5_stream_t * kstream,
 		/* addresses because krb5 protocol check those addresses */
 		/* while cyphering and decyphering data */
 		if ( kstream->flags & AUKS_KRB5_STREAM_NAT_TRAVERSAL ) {
-			klocal_addr.addrtype = AF_INET ;
-			klocal_addr.length = 5 ;
+			klocal_addr.addrtype = AF_INET6 ;
+			klocal_addr.length = 17 ;
 			klocal_addr.contents = (krb5_octet *) "dummy" ;
-			kremote_addr.addrtype = AF_INET ;
-			kremote_addr.length = 5 ;
+			kremote_addr.addrtype = AF_INET6 ;
+			kremote_addr.length = 17 ;
 			kremote_addr.contents = (krb5_octet *) "dummy";
 			auks_log("NAT traversal required, "
 				 "setting dummy addresses");

--- a/src/api/auks/auks_krb5_stream.c
+++ b/src/api/auks/auks_krb5_stream.c
@@ -113,6 +113,9 @@ extern krb5_error_code k5_rc_close(krb5_context context, krb5_rcache rc);
 #define LOCAL_PRINCIPAL 1
 #define REMOTE_PRINCIPAL 2
 
+#define INET_ADDRLEN 4
+#define INET6_ADDRLEN 16
+
 int
 auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,
 			   int flags);
@@ -376,10 +379,10 @@ auks_krb5_stream_authenticate(auks_krb5_stream_t * kstream,
 		/* while cyphering and decyphering data */
 		if ( kstream->flags & AUKS_KRB5_STREAM_NAT_TRAVERSAL ) {
 			klocal_addr.addrtype = AF_INET6 ;
-			klocal_addr.length = 17 ;
+			klocal_addr.length = INET6_ADDRLEN + 1;
 			klocal_addr.contents = (krb5_octet *) "dummy" ;
 			kremote_addr.addrtype = AF_INET6 ;
-			kremote_addr.length = 17 ;
+			kremote_addr.length = INET6_ADDRLEN  + 1;
 			kremote_addr.contents = (krb5_octet *) "dummy";
 			auks_log("NAT traversal required, "
 				 "setting dummy addresses");
@@ -788,7 +791,7 @@ auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,int flags)
 	char *remote_host;
 
 	/* stream related variables */
-	struct sockaddr_in local_addr, remote_addr;
+	struct sockaddr_in6 local_addr, remote_addr;
 	socklen_t addrlen;
 
 	krb5_error_code kstatus;
@@ -813,8 +816,9 @@ auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,int flags)
 	kstream->flags = flags;
 
 	char str_error[STR_ERROR_SIZE];
+	char str_ipv6_inet_addr[INET6_ADDRSTRLEN];
 
-	/* fill sockaddr_in structures with stream endpoints informations */
+	/* fill sockaddr_in6 structures with stream endpoints informations */
 	addrlen = sizeof(local_addr);
 	status = getsockname(stream, (struct sockaddr *) &local_addr,
 			     &addrlen);
@@ -841,7 +845,7 @@ auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,int flags)
 	auks_log("remote endpoint stream %u informations request succeed",
 		 stream);
 
-	remote_host = inet_ntoa((remote_addr.sin_addr));
+	remote_host = inet_ntop(AF_INET6, &remote_addr.sin6_addr, str_ipv6_inet_addr, sizeof(str_ipv6_inet_addr));
 	if (remote_host)
 		strncpy(kstream->remote_host, remote_host,
 			HOST_NAME_MAX);
@@ -915,12 +919,12 @@ auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,int flags)
 	}
 
 	/* kerberos : set auth context endpoints */
-	klocal_addr.addrtype = local_addr.sin_family;
-	klocal_addr.length = sizeof(local_addr.sin_addr);
-	klocal_addr.contents = (krb5_octet *) & local_addr.sin_addr;
-	kremote_addr.addrtype = remote_addr.sin_family;
-	kremote_addr.length = sizeof(remote_addr.sin_addr);
-	kremote_addr.contents = (krb5_octet *) & remote_addr.sin_addr;
+	klocal_addr.addrtype = local_addr.sin6_family;
+	klocal_addr.length = sizeof(local_addr.sin6_addr);
+	klocal_addr.contents = (krb5_octet *) & local_addr.sin6_addr;
+	kremote_addr.addrtype = remote_addr.sin6_family;
+	kremote_addr.length = sizeof(remote_addr.sin6_addr);
+	kremote_addr.contents = (krb5_octet *) & remote_addr.sin6_addr;
 	kstatus = krb5_auth_con_setaddrs(kstream->context,kstream->auth_context,
 					 &klocal_addr, &kremote_addr);
 	if (kstatus) {

--- a/src/api/xternal/xstream.c
+++ b/src/api/xternal/xstream.c
@@ -155,8 +155,8 @@ xstream_create(const char* hostname,
   int fstatus=XERROR;
   int status=-1;
 
-  /* create an AF_INET socket */
-  if ( ( sock = socket(AF_INET, SOCK_STREAM, 0) ) < 0 ){
+  /* create an AF_INET6 socket */
+  if ( ( sock = socket(AF_INET6, SOCK_STREAM, 0) ) < 0 ){
     ERROR("socket creation failed : %s",strerror(errno));
     return XERROR_STREAM_SOCKET;
   }
@@ -177,7 +177,7 @@ xstream_create(const char* hostname,
    */
   memset(&hints,0,sizeof(hints));
   hints.ai_flags=AI_PASSIVE;
-  hints.ai_family=AF_INET;
+  hints.ai_family=AF_INET6;
   
   /*
    * get 'hostname' network informations
@@ -198,9 +198,9 @@ xstream_create(const char* hostname,
     for(ai=aitop; ai; ai=ai->ai_next){
       memcpy(&addr,ai->ai_addr,ai->ai_addrlen);
       
-      if(addr.sin_family==AF_INET){
+      if(addr.sin_family==AF_INET6){
 	memset(& addresse, 0, sizeof(struct sockaddr_in));
-	addresse.sin_family = AF_INET;
+	addresse.sin_family = AF_INET6;
 	addresse.sin_port = addr.sin_port;
 	addresse.sin_addr.s_addr = addr.sin_addr.s_addr;
 	
@@ -215,7 +215,7 @@ xstream_create(const char* hostname,
 	  break;
 	} /* bind */
 
-      } /* AF_INET check */
+      } /* AF_INET6 check */
 
     } /* for(ai=...) */
 
@@ -267,7 +267,7 @@ xstream_connect(const char* hostname,
 
   /* set hint flag that indicate to get TCP/IP information only */
   memset(&hints,0,sizeof(hints));
-  hints.ai_family=AF_INET;
+  hints.ai_family=AF_INET6;
   hints.ai_socktype=SOCK_STREAM;
 
   /*
@@ -288,12 +288,12 @@ xstream_connect(const char* hostname,
       memset(&addresse, 0, sizeof(struct sockaddr_in));
       memcpy(&addr,ai->ai_addr,ai->ai_addrlen);
 
-	addresse.sin_family = AF_INET;
+	addresse.sin_family = AF_INET6;
 	addresse.sin_port = addr.sin_port;
 	addresse.sin_addr.s_addr = addr.sin_addr.s_addr;
 
-	/* create an AF_INET socket */
-	if (( sock = socket(AF_INET, SOCK_STREAM, 0) ) < 0 ){
+	/* create an AF_INET6 socket */
+	if (( sock = socket(AF_INET6, SOCK_STREAM, 0) ) < 0 ){
 	  ERROR("socket creation failed : %s",strerror(errno));
 	  fstatus=XERROR_STREAM_SOCKET;
 	  continue;


### PR DESCRIPTION
- This diff ports AUKS to IPv6. 
- The changes are based on `adapt_k5` base branch.
- We follow the porting guidelines listed here http://long.ccaba.upc.edu/long/045Guidelines/eva/ipv6.html
- Change as it stands is not backwards compatible to IPv4. 
- This is intentional for now as we want to be absolutely sure that IPv6 changes work. 
- Once this PR is well tested we can make the same code work with both IPv4 and IPv6